### PR TITLE
Simplify Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,14 @@ language: python
 python:
     - '3.6'
 cache: pip
-stages:
-    - name: before_script
-      if: branch != docs
-    - name: script
-      if: branch != docs
-    - name: after_success
-      if: branch != docs
-    - name: before_deploy
-      if: branch = docs
-    - name: deploy
-      if: branch = docs
-install: # also needed for sphinx since it imports
+install:
     - pip install -r requirements.txt
-before_script:
     - pip install -U black pytest pytest-cov
 script:
     - black --check --verbose -S --line-length=79 .
     - pytest --cov=fitgrid
 after_success:
     - pip install codecov && codecov
-before_deploy:
     - pip install sphinx sphinx_rtd_theme
     - cd docs
     - make html
@@ -34,6 +21,6 @@ deploy:
     github_token: $GITHUB_TOKEN
     keep-history: true
     on:
-        branch: docs
+        branch: dev
     target_branch: gh-pages # that's the default anyway, just to be explicit
     local_dir: docs/build/html


### PR DESCRIPTION
Just run two builds on pull requests, who cares. It's not worth the
complexity to try and separate docs. Docs are deployed on pushes to dev.