### PR TITLE
Get first group of groupby correctly.

### DIFF
--- a/fitgrid/epochs.py
+++ b/fitgrid/epochs.py
@@ -87,7 +87,7 @@ class Epochs:
         self.channels = channels
         self.table = table
         self._snapshots = snapshots
-        self._epoch_index = snapshots.get_group(0).index.copy()
+        self._epoch_index = tools.get_first_group(snapshots).index.copy()
 
     def _validate_LHS(self, LHS):
 

--- a/fitgrid/tools.py
+++ b/fitgrid/tools.py
@@ -25,3 +25,10 @@ def get_index_duplicates_table(df, level):
         msg += '{0:<20} {1}\n'.format(value, ', '.join(locations))
 
     return msg
+
+
+def get_first_group(groupby):
+
+    first_group_name = list(groupby.groups)[0]
+    first_group = groupby.get_group(first_group_name)
+    return first_group

--- a/tests/test_fitgrid.py
+++ b/tests/test_fitgrid.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from .context import fitgrid
 from fitgrid.errors import FitGridError
+from fitgrid import tools
 import matplotlib
 
 matplotlib.use('Agg')
@@ -51,7 +52,8 @@ def test__residuals_have_long_form_and_correct_index():
         RHS='categorical + continuous',
     )
 
-    single_epoch = epochs._snapshots.get_group(0)
+    single_epoch = tools.get_first_group(epochs._snapshots)
+
     assert single_epoch.index.equals(grid.resid.index.levels[1])
 
 
@@ -69,7 +71,7 @@ def test__epoch_id_substitution():
     epochs = fitgrid.epochs_from_dataframe(data, channels)
 
     # remember epoch_index
-    epoch_index = epochs._snapshots.get_group(0).index
+    epoch_index = tools.get_first_group(epochs._snapshots).index
     assert (epoch_index == unusual_index).all()
 
     # take just two channels for speed


### PR DESCRIPTION
closes #38 
groupby.get_group() retrieves groups by name, not by index, so

    groupby.get_group(0)

does NOT retrieve the first group.