### PR TITLE
Revert to a single Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language: python
 python:
     - '3.6'
 cache: pip
-matrix:
-  include:
-  - name: "Exclude lmer fitter"
-    env: TEST_SUITE=--ignore=tests/test_utils_lmer.py
-  - name: "Lmer fitter only"
-    env: TEST_SUITE=tests/test_utils_lmer.py
 install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
@@ -21,7 +15,7 @@ install:
     - pip install black
 script:
     - black --check --verbose -S --line-length=79 .
-    - pytest --cov=fitgrid $TEST_SUITE
+    - pytest --cov=fitgrid
 after_success:
     - pip install codecov && codecov
 before_deploy:


### PR DESCRIPTION
Lmer fitter tests are much faster now, no need for separate build.