### PR TITLE
Add FitGrid saving and loading (grid.save and fitgrid.load_grid).

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -19,11 +19,14 @@ Data generation
 Data ingestion
 ==============
 
-Functions that read epochs tables and create ``Epochs``.
+Functions that read epochs tables and create ``Epochs`` and load ``FitGrid``
+objects.
 
 .. autofunction:: epochs_from_dataframe
 
 .. autofunction:: epochs_from_hdf
+
+.. autofunction:: load_grid
 
 ==================
 ``Epochs`` methods
@@ -50,3 +53,5 @@ Plotting and statistics.
 .. autofunction:: fitgrid.fitgrid.FitGrid.plot_betas
 
 .. autofunction:: fitgrid.fitgrid.FitGrid.plot_adj_rsquared
+
+.. autofunction:: fitgrid.fitgrid.FitGrid.save

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -1,5 +1,5 @@
 from .fake_data import generate
-from .io import epochs_from_hdf, epochs_from_dataframe
+from .io import epochs_from_hdf, epochs_from_dataframe, load_grid
 
 #: default epoch identifier
 EPOCH_ID = 'Epoch_idx'

--- a/fitgrid/fitgrid.py
+++ b/fitgrid/fitgrid.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pickle
 from functools import lru_cache
 import warnings
 
@@ -223,7 +224,7 @@ class FitGrid:
         """
 
         if not hasattr(self.tester, name):
-            raise FitGridError(f'No such attribute: {name}.')
+            raise AttributeError(f'No such attribute: {name}.')
 
         temp = self._grid.applymap(lambda x: getattr(x, name))
         return _expand(temp, self._epoch_index)
@@ -254,6 +255,20 @@ class FitGrid:
 
         samples, chans = self._grid.shape
         return f'{samples} by {chans} FitGrid of type {type(self.tester)}.'
+
+    def save(self, filename):
+        """Save FitGrid object to file (reload with ``fitgrid.load_grid``).
+
+        Parameters
+        ----------
+        filename : str
+            file name to use
+
+        """
+
+        with open(filename, 'wb') as file:
+            kernel = self._grid, self._epoch_index
+            pickle.dump(kernel, file, protocol=pickle.HIGHEST_PROTOCOL)
 
     def plot_betas(self, legend_on_bottom=False):
         """Plot betas of the model, one plot per channel, overplotting betas.

--- a/fitgrid/io.py
+++ b/fitgrid/io.py
@@ -1,5 +1,7 @@
 import pandas as pd
+import pickle
 from .epochs import Epochs
+from .fitgrid import FitGrid
 from .errors import FitGridError
 
 
@@ -63,3 +65,23 @@ def epochs_from_dataframe(dataframe, channels='default'):
         an Epochs object with the data
     """
     return Epochs(dataframe, channels)
+
+
+def load_grid(filename):
+    """Load a FitGrid object from file (created by running grid.save).
+
+    Parameters
+    ----------
+    filename : str
+        indicates file to load from
+
+    Returns
+    -------
+    grid : FitGrid
+        loaded FitGrid object
+    """
+
+    with open(filename, 'rb') as file:
+        _grid, _epoch_index = pickle.load(file)
+
+    return FitGrid(_grid, _epoch_index)

--- a/tests/test_fitgrid.py
+++ b/tests/test_fitgrid.py
@@ -1,7 +1,10 @@
 import pytest
 import numpy as np
 import pandas as pd
-from .context import fitgrid
+import uuid
+import os
+from pathlib import Path
+from .context import fitgrid, tpath
 from fitgrid.errors import FitGridError
 from fitgrid.fitgrid import FitGrid
 from fitgrid import tools
@@ -216,3 +219,35 @@ def test__smoke_plot_adj_rsquared():
         RHS='categorical + continuous',
     )
     grid.plot_adj_rsquared()
+
+
+def test__save_load_grid_lm(tpath):
+
+    epochs = fitgrid.generate(n_samples=2, n_channels=2)
+    grid = epochs.lm(RHS='categorical + continuous')
+
+    TEST_FILENAME = tpath / 'data' / str(uuid.uuid4())
+    grid.save(TEST_FILENAME)
+
+    loaded_grid = fitgrid.load_grid(TEST_FILENAME)
+
+    assert dir(grid) == dir(loaded_grid)
+    assert grid.params.equals(loaded_grid.params)
+
+    os.remove(TEST_FILENAME)
+
+
+def test__save_load_grid_lmer(tpath):
+
+    epochs = fitgrid.generate(n_samples=2, n_channels=1)
+    grid = epochs.lmer(RHS='continuous + (continuous | categorical)')
+
+    TEST_FILENAME = str(tpath / 'data' / str(uuid.uuid4()))
+    grid.save(TEST_FILENAME)
+
+    loaded_grid = fitgrid.load_grid(TEST_FILENAME)
+
+    assert dir(grid) == dir(loaded_grid)
+    assert grid.coefs.equals(loaded_grid.coefs)
+
+    os.remove(TEST_FILENAME)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -17,3 +17,6 @@ def test__epochs_from_dataframe_good_data():
         n_epochs=10, n_samples=100, n_categories=2, n_channels=32
     )
     fitgrid.epochs_from_dataframe(table, channels)
+
+
+# fitgrid.load_grid is tested in test_fitgrid.py


### PR DESCRIPTION
FitGrid objects can now be saved to files and loaded from files. This is
achieved by pickling a tuple containing grid._grid and
grid._epoch_index. The highest protocol available in pickle is used. For
Python 3.6 this means protocol 4. Loading is done by unpickling this
tuple and creating a new FitGrid object using the constructor.