### PR TITLE
Import matplotlib and set backend for headless for all tests.

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -3,6 +3,11 @@ import sys
 from pathlib import Path
 import pytest
 
+# the following two lines are necessary to avoid segfaults when headless
+import matplotlib
+
+matplotlib.use('Agg')
+
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 )

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -6,10 +6,6 @@ from fitgrid import fake_data
 from fitgrid.errors import FitGridError
 from fitgrid.epochs import Epochs
 
-import matplotlib
-
-matplotlib.use('Agg')
-
 
 def test_epochs_unequal_snapshots():
 

--- a/tests/test_fitgrid.py
+++ b/tests/test_fitgrid.py
@@ -7,9 +7,6 @@ from .context import fitgrid, tpath
 from fitgrid.errors import FitGridError
 from fitgrid.fitgrid import FitGrid, LMFitGrid, LMERFitGrid
 from fitgrid import tools
-import matplotlib
-
-matplotlib.use('Agg')
 
 
 def test__correct_channels_in_fitgrid():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,9 +4,6 @@ from statsmodels.formula.api import ols
 from .context import fitgrid
 from fitgrid.errors import FitGridError
 from fitgrid.fitgrid import LMFitGrid, LMERFitGrid
-import matplotlib
-
-matplotlib.use('Agg')
 
 
 def test_epochs_lm_bad_inputs():

--- a/tests/test_utils_lmer.py
+++ b/tests/test_utils_lmer.py
@@ -1,9 +1,6 @@
 import pytest
 from pathlib import Path
 import pandas as pd
-import matplotlib
-
-matplotlib.use('Agg')
 from matplotlib import pyplot as plt
 from .context import fitgrid, tpath
 from fitgrid.utils import lmer as fgu


### PR DESCRIPTION
This is necessary to avoid segfaults from PyQt5 when running headless.
These imports used to be scattered across test files, they are now
centralized in context.py.