### PR TITLE
Restrict nbconvert version to avoid version 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 after_success:
     - pip install codecov && codecov
 before_deploy:
-    - pip install sphinx sphinx_rtd_theme jupyter nbsphinx
+    - pip install sphinx sphinx_rtd_theme jupyter nbsphinx nbconvert!=5.4
     - conda install -c conda-forge pandoc
     - pip install -e . # install fitgrid locally so it can be imported in the notebook
     - conda list


### PR DESCRIPTION
This causes nbsphinx failures, for more details see:

https://github.com/spatialaudio/nbsphinx/issues/202
https://github.com/jupyter/nbconvert/issues/878
https://github.com/jupyter/nbconvert/pull/886

Should be fixed by the next nbconvert release (5.5).