### PR TITLE
0.4.3

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -7,11 +7,12 @@ channels:
 dependencies:
     - pytest
     - pytest-cov
+    - mro-base
     - rpy2
     - python=3.6
     - pymer4
-    - r-lme4
-    - r-lmerTest
+    - r-lme4=1.1_17
+    - r-lmerTest=3.0_1
     - numpy=1.15.4
     - scipy
     - pandas

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: fitgrid
-    version: "0.4.2"
+    version: "0.4.3-dev"
 
 source:
     path: ../

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: fitgrid
-    version: "0.4.3-dev"
+    version: "0.4.3"
 
 source:
     path: ../
@@ -16,8 +16,8 @@ requirements:
         - python=3.6
         - rpy2
         - pymer4
-        - r-lme4
-        - r-lmerTest
+        - r-lme4=1.1_17
+        - r-lmerTest=3.0_1
         - numpy=1.15.4
         - scipy
         - pandas

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -8,4 +8,4 @@ from .io import (
 from .models import run_model, lm, lmer
 from . import utils, defaults
 
-__version__ = "0.4.2"
+__version__ = "0.4.3-dev.0.0"

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -8,4 +8,4 @@ from .io import (
 from .models import run_model, lm, lmer
 from . import utils, defaults
 
-__version__ = "0.4.3-dev.0.0"
+__version__ = "0.4.3"


### PR DESCRIPTION
in`conda/environment.yaml` and `conda/meta.yaml` 

* pinned R to `mro-base` which wasn't, then was, now isn't Anaconda Cloud default. cmon.
* pinned `r-lme4` and `r-lmertest` versions, turns out more the recent versions (accidentally installed over installed over `r-base`) handle warnings differently and broke the fitgrid `utils.summary::summarize()` checksums in the pytests.