### PR TITLE
testing numpy 1.16.4 as minimal pin to pass travis

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -12,7 +12,7 @@ dependencies:
     - pymer4
     - r-lme4
     - r-lmerTest
-    - numpy
+    - numpy<=1.16.4
     - scipy
     - pandas
     - matplotlib

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
         - pymer4
         - r-lme4
         - r-lmerTest
-        - numpy
+        - numpy<=1.16.4
         - scipy
         - pandas
         - matplotlib


### PR DESCRIPTION
## Minimal pin to get `fitgrid` 0.4.4.X to pass

During testing the unpinned environment I installed the `i-rkernel`, which downgraded `pbdzmq` and `zeromzq` and `pytest` started passing.

I don't know what's causing the problem, but pinning `numpy<=1.16.4` is sufficient to get pytest passing again and `numpy==1.16.5` fails.

`1.16.5` is a bright line for numpy, the last series to support Python 2.7 and only good for 3.5-3.7

https://numpy.org/devdocs/release/1.16.5-notes.html

So for fitgrid, `4.X.Y` just maintenance patches for Python 3.5-3.7 for now.

The next series can work to Python 3.8

---
Here is the sequence ...
---
## Additions and downgrades that allowed fitgrid `pytest` pass

```
2019-09-16 07:02:47  (rev 2)
     openssl  {1.1.1c -> 1.1.1d}
     pyzmq  {18.1.0 -> 17.1.2}
     zeromq  {4.3.1 -> 4.2.5}
    +r-base64enc-0.1_3
    +r-evaluate-0.13
    +r-htmltools-0.3.6
    +r-irdisplay-0.7.0
    +r-irkernel-0.8.15
    +r-jsonlite-1.6
    +r-pbdzmq-0.3_3
    +r-repr-0.19.2
    +r-uuid-0.1_2
```
Could be an addition that filled in a missing dependency or the `zeromq` related downgrades

## First (unlikely) thing to check is a missing dependency 

Candidates ... all missing from default fitgrid_compat environment
* r-repr     # import rbase64enc
* r-base64enc
* r-pdbzmq   # big data zmq wrapper
* r-evaluate         r/noarch::r-evaluate-0.13-r36h6115d3f_0
* r-uuid             r/linux-64::r-uuid-0.1_2-r36h96ca727_4
* r-irkernel         r/noarch::r-irkernel-0.8.15-r36_0
* r-irdisplay        r/noarch::r-irdisplay-0.7.0-r36h6115d3f_0


## Test 1

conda install -c r r-base64enc

   The following NEW packages will be INSTALLED:

    r-base64enc        r/linux-64::r-base64enc-0.1_3-r36h96ca727_4

pytest FAILED

## Test 2

    conda install -c r r-repr

    The following NEW packages will be INSTALLED:

     r-htmltools        r/linux-64::r-htmltools-0.3.6-r36h29659fb_0
     r-jsonlite         r/linux-64::r-jsonlite-1.6-r36h96ca727_0
     r-repr             r/noarch::r-repr-0.19.2-r36h6115d3f_0

pytest FAILED


# Test 3

    conda install -c r r-pbdzmq 

    The following NEW packages will be INSTALLED:

    libsodium          pkgs/main/linux-64::libsodium-1.0.16-h1bed415_0
    r-pbdzmq           r/linux-64::r-pbdzmq-0.3_3-r36h29659fb_0
    zeromq             pkgs/main/linux-64::zeromq-4.2.5-hf484d3e_1

pytest FAILED


# Test 4

     conda install -c r r-evaluate

     The following NEW packages will be INSTALLED:

      r-evaluate         r/noarch::r-evaluate-0.13-r36h6115d3f_0

pytest FAILED


# Test 5

    conda install -c r r-uuid

    The following NEW packages will be INSTALLED:

    r-uuid             r/linux-64::r-uuid-0.1_2-r36h96ca727_4

pytest FAILED


# Test 6

    conda install -c r r-irkernel

    The following NEW packages will be INSTALLED:
 
    r-irdisplay        r/noarch::r-irdisplay-0.7.0-r36h6115d3f_0
    r-irkernel         r/noarch::r-irkernel-0.8.15-r36_0

pytest FAILED

## Interim Conclusion

Problem was not missing `r-*` dependencies. As expected.

Problem seems to be pyzmq and/or zeromq

Note: pyzmq and zerozmq are not in the fitgrid env by default

# Test 7

    conda install pyzmq

    The following NEW packages will be INSTALLED:

    pyzmq              pkgs/main/linux-64::pyzmq-17.1.2-py36h14c3975_0

pytest FAILED

Notes:

* comparison of fitgrid_refresh (pytests pass) with fitgrid_0.4.4.dev0
shows same versions of r-* including downgraded zero mq related python packages.

* numpy versions differ


# Test 8

downgraded numpy from 1.17.2 to 1.16.4 with previously downgraded zmq friends.

    numpy                     1.16.4           py36h7e9f1db_0  
    numpy-base                1.16.4           py36hde5b4d6_0  

pytests PASS


# Test 9

candidate minimal pin for fitgrid 0.4.4

    numpy<1.17
    zeromq<4.3

pytest FAILED 

Note

    numpy==1.16.5
    zeromq==4.2.5

So zeromq<4.3 is not sufficient

# Test 10

candidate minimal pin for fitgrid 0.4.4

    numpy<=1.16.4

pytest PASS

Note: pinning numpy 1.16.4 also holds zeromq at 4.2.5


