### PR TITLE
0.4.5 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - conda info -a
 install:
     - conda build conda -c kutaslab  # for pymer4
-    - conda convert -p all /home/travis/miniconda/conda-bld/linux-64/fitgrid-*.tar.bz2 
+    - conda convert -p all /home/travis/miniconda/conda-bld/linux-64/fitgrid-*.tar.bz2
     - conda create --name fitgrid_env -c kutaslab pymer4
     - conda activate fitgrid_env  # so tests run in env as installed by conda
     - conda install -c local fitgrid  # install after or conda chooses v0.2.2 !?
@@ -31,15 +31,14 @@ before_deploy:
     - conda list
     - make -C docs html
     - touch docs/build/html/.nojekyll
-
 deploy:
     - provider: script
       skip_cleanup: true
       script: bash ./ci/conda_upload.sh
       on:
-          all_branches: true  # to dry run uploads 
-          # tags: true  #  attempt on tagged releases only ... untested
-          # condition: $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  # ditto
+          # all_branches: true  # for testing
+          tags: true            # restrict to vN.N.N tags
+          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$
 
     - provider: pages
       verbose: true
@@ -47,6 +46,20 @@ deploy:
       github_token: $GITHUB_TOKEN
       keep-history: true
       on:
-          branch: master
+          # all_branches: true  # for testing
+          tags: true
+          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$
       target_branch: gh-pages  # that's the default anyway, just to be explicit
       local_dir: docs/build/html
+
+    - provider: pypi
+      skip_cleanup: true
+      user: "__token__"
+      password: $PYPI_TOKEN
+      on:
+          # do NOT test PyPI on all_branches. file names work like
+          # UUIDs on PyPI, can be deleted but not freed. Use unique
+          # N.N.N.devN, aN, bN, rcN versions if you must test deploy
+          # to PyPI
+          tags: true
+          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ deploy:
           # condition: $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  # ditto
 
     - provider: pages
+      verbose: true
       skip_cleanup: true
       github_token: $GITHUB_TOKEN
       keep-history: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
+env:
+    - PACKAGE_NAME: fitgrid  # for the conda_upload.sh deploy script
 language: minimal
-install:
+before_install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
+    - source $HOME/miniconda/etc/profile.d/conda.sh && conda activate
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
+    - conda install -q conda-build conda-verify
     - conda info -a
-    - conda env create -f conda/environment.yml
-    - source activate fitgrid_compat
+install:
+    - conda build conda -c kutaslab  # for pymer4
+    - conda convert -p all /home/travis/miniconda/conda-bld/linux-64/fitgrid-*.tar.bz2 
+    - conda create --name fitgrid_env -c kutaslab pymer4 
+    - conda activate fitgrid_env  # so tests run in env as installed by conda
+    - conda install -c local fitgrid
+    - conda install black pytest-cov
     - conda list
     - lscpu
     - python -c 'import numpy; numpy.show_config()'
-    - pip install black
 script:
     - black --check --verbose -S --line-length=79 .
     - pytest --cov=fitgrid
@@ -20,17 +27,22 @@ after_success:
 before_deploy:
     - pip install sphinx sphinx_rtd_theme jupyter nbsphinx nbconvert!=5.4
     - conda install -c conda-forge pandoc
-    - pip install -e . # install fitgrid locally so it can be imported in the notebook
+    - pip install -e .  # install fitgrid locally so it can be imported in the notebook
     - conda list
     - cd docs
     - make html
     - touch build/html/.nojekyll
 deploy:
-    provider: pages
-    skip_cleanup: true
-    github_token: $GITHUB_TOKEN
-    keep-history: true
-    on:
-        branch: master
-    target_branch: gh-pages # that's the default anyway, just to be explicit
-    local_dir: docs/build/html
+    - provider: script
+      skip_cleanup: true
+      script: bash ./ci/conda_upload.sh
+      on:
+          all_branches: true
+    - provider: pages
+      skip_cleanup: true
+      github_token: $GITHUB_TOKEN
+      keep-history: true
+      on:
+          branch: master
+      target_branch: gh-pages  # that's the default anyway, just to be explicit
+      local_dir: docs/build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
 install:
     - conda build conda -c kutaslab  # for pymer4
     - conda convert -p all /home/travis/miniconda/conda-bld/linux-64/fitgrid-*.tar.bz2 
-    - conda create --name fitgrid_env -c kutaslab pymer4 
+    - conda create --name fitgrid_env -c kutaslab pymer4
     - conda activate fitgrid_env  # so tests run in env as installed by conda
-    - conda install -c local fitgrid
+    - conda install -c local fitgrid  # install after or conda chooses v0.2.2 !?
     - conda install black pytest-cov
     - conda list
     - lscpu
@@ -29,15 +29,18 @@ before_deploy:
     - conda install -c conda-forge pandoc
     - pip install -e .  # install fitgrid locally so it can be imported in the notebook
     - conda list
-    - cd docs
-    - make html
-    - touch build/html/.nojekyll
+    - make -C docs html
+    - touch docs/build/html/.nojekyll
+
 deploy:
     - provider: script
       skip_cleanup: true
       script: bash ./ci/conda_upload.sh
       on:
-          all_branches: true
+          all_branches: true  # to dry run uploads 
+          # tags: true  #  attempt on tagged releases only ... untested
+          # condition: $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  # ditto
+
     - provider: pages
       skip_cleanup: true
       github_token: $GITHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -3,22 +3,24 @@
 
 # fitgrid
 
-Run models on a 2D grid where each cell holds a dataset.
+A Python library for modeling time-varying patterns of activity in sensor-array data streams on a 2-D grid.
+
+## Documentation
+
+Available [here](https://kutaslab.github.io/fitgrid).
+
+
+## Recommended for full installation
+
+    conda install -c kutaslab fitgrid
+
+Alternatively, with no `lmer` support,
+
+    pip3 install fitgrid
+
 
 ## Demo
 
 Click this button to launch a demo notebook:
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/kutaslab/fitgrid/master?filepath=notebooks/Demo.ipynb)
-
-## Installation
-
-    conda install -c kutaslab fitgrid
-
-for full support.  Alternatively (with no `lmer` support),
-
-    pip3 install fitgrid
-
-## Documentation
-
-Available [here](https://kutaslab.github.io/fitgrid).

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -1,0 +1,91 @@
+# Anaconda Cloud package uploader
+# 
+# Runs but doesn't attempt the upload unless 
+# 
+#  * the package version in meta.yaml is {% version = "N.N.N" %} 
+# 
+#  * the current build is a tag build vN.N.N such as triggered by a
+#    github release
+
+# some guarding
+if [[ -z ${CONDA_DEFAULT_ENV} ]]; then
+    echo "activate a conda env before running conda_upload.sh"
+    exit -1
+fi
+
+# meant for a TravisCI deploy environment but easily tricked into running locally
+if [[ "$TRAVIS" != "true" || -z "$TRAVIS_BRANCH" || -z "${PACKAGE_NAME}" ]]; then
+    echo "conda_upload.sh is meant to run on TravisCI"
+    exit -2
+fi
+
+# set the parent of conda-bld, the else isn't needed for TravisCI but 
+# simplifies local testing
+if [ $USER = "travis" ]; then
+    bld_prefix="/home/travis/miniconda"  # from the .travis.yml
+else
+    bld_prefix=${CONDA_PREFIX}
+fi
+
+# on TravisCI there should be a single linux-64 package tarball. insist
+tarball=`/bin/ls -1 ${bld_prefix}/conda-bld/linux-64/${PACKAGE_NAME}-*-*.tar.bz2`
+n_tarballs=`echo "${tarball}" | wc -w`
+if (( $n_tarballs != 1 )); then
+    echo "found $n_tarballs package tarballs there must be exactly 1"
+    echo "$tarball"
+    exit -3
+fi
+
+# whatever version string was set in the conda meta.yaml
+version=`echo $tarball | sed -n "s/.*${PACKAGE_NAME}-\(.\+\)-.*/\1/p"`
+
+# extract the numeric major.minor.patch portion of version, possibly empty
+mmp=`echo $version | sed -n "s/\(\([0-9]\+\.\)\{1,2\}[0-9]\+\).*/\1/p"`
+
+# Are we building a release version according to the convention that
+# releases are tagged vMajor.Minor.Release?
+#
+# * is $version = $mmp then version a strict numeric
+#   Major.Minor.Patch, not further decorated, e.g., with .dev this or
+#   rc that?
+# 
+# * is the tag vMajor.Minor.Patch (TravisCI treats tagged commits as a branch)?
+if [[ "${version}" = "$mmp" && $TRAVIS_BRANCH = v$mmp ]]; then
+    is_release="true"
+else
+    is_release="false"
+fi
+
+# POSIX trick sets $ANACONDA_TOKEN if unset or empty string 
+ANACONDA_TOKEN=${ANACONDA_TOKEN:-[not_set]}
+conda_cmd="anaconda --token $ANACONDA_TOKEN upload ${tarball}"
+
+# thus far ...
+echo "conda meta.yaml version: $version"
+echo "package name: $PACKAGE_NAME"
+echo "conda-bld: ${bld_prefix}/conda-bld/linux-64"
+echo "tarball: $tarball"
+echo "travis branch: $TRAVIS_BRANCH"
+echo "is_release: $is_release"
+echo "conda upload command: ${conda_cmd}"
+
+# if the token is in the ENV and this is a vN.N.N tagged commit
+#    attempt the upload 
+# else
+#    skip the upload and exit happy
+# 
+# conda upload knows the destination from the token
+if [[ $ANACONDA_TOKEN != "[not_set]" && $is_release = "true" ]]; then
+
+    echo "uploading to Anconda Cloud: $PACKAGE_NAME$ $version ..."
+    if ${conda_cmd}; then
+    	echo "OK"
+    else
+    	echo "Failed"
+    	exit -5
+    fi
+else
+    echo "$PACKAGE_NAME $TRAVIS_BRANCH $version conda_upload.sh dry run ... OK"
+fi
+exit 0
+

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -52,6 +52,7 @@ mmp=`echo $version | sed -n "s/\(\([0-9]\+\.\)\{1,2\}[0-9]\+\).*/\1/p"`
 # * is the tag vMajor.Minor.Patch (TravisCI treats tagged commits as a branch)?
 if [[ "${version}" = "$mmp" && $TRAVIS_BRANCH = v$mmp ]]; then
     is_release="true"
+    conda install anaconda-client
 else
     is_release="false"
 fi

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,24 +1,34 @@
+{% set version = "0.4.5.dev" %}
+{% set np_pin = "1.16.4" %}
+{% set py_pin = "3.6" %}
+
 package:
     name: fitgrid
-    version: "0.4.4"
+    version: {{ version }}
 
 source:
-    path: ../
+    # path: ../
+    git_url: ../  # triggers GIT_X_Y env vars on TravisCI
 
 build:
+    # setting string embeds git short SHA in conda tarball name
     script: python setup.py install --single-version-externally-managed --record=record.txt
+    string: {{ environ.get('GIT_BUILD_STR', "no_tags_on_travis_br") }}  # github release builds are tagged
 
 requirements:
-    build:
-        - python
+    # build:
+    #    - python
+    host:
+        - python ={{ py_pin }}
+        - numpy <={{ np_pin }}
 
     run:
-        - python=3.6
+        - python ={{ py_pin }}
+        - numpy <={{ np_pin }}
         - rpy2
         - pymer4
         - r-lme4
         - r-lmerTest
-        - numpy<=1.16.4
         - scipy
         - pandas
         - matplotlib

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,7 +13,8 @@ source:
 build:
     # setting string embeds git short SHA in conda tarball name
     script: python setup.py install --single-version-externally-managed --record=record.txt
-    string: {{ environ.get('GIT_BUILD_STR', "no_tags_on_travis_br") }}  # github release builds are tagged
+    # github vN.N.N release builds are tagged with git short hash and conda build number, Travis deploys should be 0
+    string: {{ environ.get('GIT_BUILD_STR', "no_tags_on_travis_br") }}_{{ environ.get("PKG_BUILDNUM", "no_pkg_buildnum") }}
 
 requirements:
     # build:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,16 +24,17 @@ requirements:
 
     run:
         - python ={{ py_pin }}
-        - numpy <={{ np_pin }}
         - rpy2
         - pymer4
         - r-lme4
         - r-lmerTest
+        - numpy <={{ np_pin }}
         - scipy
         - pandas
         - matplotlib
         - statsmodels
         - pytables
+        - pyarrow
         - patsy
         - tqdm
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.5.dev" %}
+{% set version = "0.4.5" %}
 {% set np_pin = "1.16.4" %}
 {% set py_pin = "3.6" %}
 

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -8,4 +8,4 @@ from .io import (
 from .models import run_model, lm, lmer
 from . import utils, defaults
 
-__version__ = "0.4.5.dev"
+__version__ = "0.4.5"

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -8,4 +8,4 @@ from .io import (
 from .models import run_model, lm, lmer
 from . import utils, defaults
 
-__version__ = "0.4.4"
+__version__ = "0.4.5.dev"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,11 @@ setup(
     author='Thomas P. Urbach, Andrey Portnoy',
     author_email='turbach@ucsd.edu, aportnoy@ucsd.edu',
     url='https://github.com/kutaslab/fitgrid',
-    license='BSD-3-Clause',
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: BSD License",
+        "Intended Audience :: Science/Research",
+    ],
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'patsy',


### PR DESCRIPTION
Knits TravisCI together with conda

.travis.yml

* install:  `conda build conda` makes a fitgrid tarball from the meta.yaml, then does a `conda install fitgrid -c local` into a fresh conda env to run pytests

* deploy: a new script provider uploads converted tarballs to the Anaconda Cloud kutaslab channel on all and only github release versions tagged vN.N.N

Pros: fitgrid pytests run in a conda env as installed by conda and github. All and only github release versions tagged vN.N.N are automatically packaged and uploaded to Anaconda Cloud with tarball build strings matching the release vN.N.N and git commit short hash (this is important).

Cons: TravisCI builds are slower in the install stage, the before_deploy stage triggers on every build not just master. The slowdown is a nuisance but not intractable. Not much help for the install stage since the point is to pytest fitgrid in whatever environment conda feels like building that day. Possible fixes for the deploy stage are to make conda uploads conditional on vN.N.N tags (but this means no upload dry run reports) and/or move the before_build stage sphinx setup to a script provider for gh_pages (this works in testing on kutaslab/spudtr); a workaround is simply to temporarily comment out deployment while working on dev branches.