### PR TITLE
for release 0.4.10

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,7 @@
 {% set version = "0.4.9" %}
 {% set np_pin = "1.16.4" %}
 {% set py_pin = "3.6" %}
+{% set pd_pin = "0.1.0" %} 
 
 package:
     name: fitgrid
@@ -31,7 +32,7 @@ requirements:
         - r-lmerTest
         - numpy <={{ np_pin }}
         - scipy
-        - pandas
+        - pandas <{{ pd_pin }}
         - matplotlib
         - statsmodels
         - pytables

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.4.9" %}
 {% set np_pin = "1.16.4" %}
 {% set py_pin = "3.6" %}
-{% set pd_pin = "0.1.0" %} 
+{% set pd_pin = "1.0.0" %}
 
 package:
     name: fitgrid


### PR DESCRIPTION
pinned pandas < 1.0.0 or else rpy2 breaks and takes fitgrid.lmer() down with it.