### PR TITLE
update for pymer4 0.7.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,9 @@ deploy:
       skip_cleanup: true
       script: bash ./ci/conda_upload.sh
       on:
-          # all branches ok for testing, conda uploads can be deleted and
-          # filenames reused. branches other than vN.N.N are --label pre_release
-          # all_branches: true
-          tags: true
-          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  # match vN.N.N
+          # conda_upload.sh switches on the branch and version string for a
+          # dry run or upload to conda label pre-release or label main
+          all_branches: true
 
     # homegrown replacement for TravisCI gh_pages provider
     - provider: script
@@ -48,8 +46,7 @@ deploy:
       script: bash ./ci/ghpages_upload.sh
       on:
           # all_branches: true   # testing only
-          tags: true
-          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$
+          branch: master  # allow doc updates to master between tagged releases
 
     - provider: pypi
       skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,8 @@ before_install:
     - conda install -q conda-build conda-verify
     - conda info -a
 install:
-#    - conda build conda -c kutaslab  -# for pymer4
-#    - conda convert -p all /home/travis/miniconda/conda-bld/linux-64/fitgrid-*.tar.bz2
-    # - conda create --name fitgrid_env -c kutaslab pymer4
-    # - conda activate fitgrid_env  # so tests run in env as installed by conda
-    # - conda install -c local fitgrid  # install after or conda chooses v0.2.2 !?
 
-    # for 0.5.0
+    #  09/03/20 build w/ 3.7, conda dependency solver fails ugly w/ py3.8
     - conda build conda --python 3.7 -c turbach/label/pre-release -c defaults -c conda-forge
     - conda create -n fitgrid_env fitgrid -c local -c turbach/label/pre-release -c defaults -c conda-forge
     - conda activate fitgrid_env

--- a/fitgrid/utils/summary.py
+++ b/fitgrid/utils/summary.py
@@ -41,7 +41,6 @@ def summarize(
     RHS,
     parallel=True,
     n_cores=4,
-    save_as=None,
     **kwargs,
 ):
     """Fit the data with one or more model formulas and return summary information.
@@ -72,10 +71,6 @@ def summarize(
     n_cores : int
        number of cores to use. See what works, but golden rule if running
        on a shared machine.
-
-    save_as : 2-ple of str, optional
-       write the summary dataframe to disk with
-       `pd.to_hdf(path, key, format='fixed')`
 
     **kwargs : key=value arguments passed to the modeler, optional
 
@@ -148,9 +143,8 @@ def summarize(
     else:
         raise ValueError("modeler must be 'lm' or 'lmer'")
 
-    # single formula -> singleton list
-    if isinstance(RHS, str):
-        RHS = [RHS]
+    # promote RHS scalar str to singleton list
+    RHS = np.atleast_1d(RHS).tolist()
 
     # loop through model formulas fitting and scraping summaries
     summaries = []
@@ -170,18 +164,6 @@ def summarize(
 
     summary_df = pd.concat(summaries)
     _check_summary_df(summary_df, epochs_fg)
-
-    del summaries
-
-    if save_as is not None:
-        try:
-            fname, group = save_as
-            summary_df.to_hdf(fname, group)
-        except Exception as fail:
-            warnings.warn(
-                f"save_as={save_as} failed: {fail}. You can try to "
-                "save the returned dataframe with pandas.to_hdf()"
-            )
 
     return summary_df
 

--- a/fitgrid/utils/summary.py
+++ b/fitgrid/utils/summary.py
@@ -35,13 +35,7 @@ PER_MODEL_KEY_LABELS = ['AIC', 'SSresid', 'has_warning', 'logLike', 'sigma2']
 
 
 def summarize(
-    epochs_fg,
-    modeler,
-    LHS,
-    RHS,
-    parallel=True,
-    n_cores=4,
-    **kwargs,
+    epochs_fg, modeler, LHS, RHS, parallel=True, n_cores=4, **kwargs,
 ):
     """Fit the data with one or more model formulas and return summary information.
 

--- a/tests/test_utils_summary.py
+++ b/tests/test_utils_summary.py
@@ -135,6 +135,20 @@ def test__lmer_get_summaries_df(epoch_id, time):
     fitgrid.utils.summary._check_summary_df(summaries_df, fgrid_lmer)
 
 
+
+bad_epochs_mark = pytest.mark.xfail(reason=TypeError, strict=True)
+@pytest.mark.parametrize(
+    "epoch_arg",
+    [
+        pytest.param(np.array([]), marks=bad_epochs_mark),
+        pytest.param(pd.DataFrame(), marks=bad_epochs_mark),
+    ]
+)
+def test_summarize_args(epoch_arg):
+    """ test summary.summarize argument guards"""
+    fitgrid.utils.summary.summarize(epoch_arg, None, None, None, None, None)
+
+
 def test_summarize():
     """test main wrapper to scrape summaries lm and lmer grids"""
 

--- a/tests/test_utils_summary.py
+++ b/tests/test_utils_summary.py
@@ -135,14 +135,16 @@ def test__lmer_get_summaries_df(epoch_id, time):
     fitgrid.utils.summary._check_summary_df(summaries_df, fgrid_lmer)
 
 
-
+# summary.summarize args
 bad_epochs_mark = pytest.mark.xfail(reason=TypeError, strict=True)
+
+
 @pytest.mark.parametrize(
     "epoch_arg",
     [
         pytest.param(np.array([]), marks=bad_epochs_mark),
         pytest.param(pd.DataFrame(), marks=bad_epochs_mark),
-    ]
+    ],
 )
 def test_summarize_args(epoch_arg):
     """ test summary.summarize argument guards"""


### PR DESCRIPTION
This updates the pymer4 conda dependency in anticipation of official conda packaging on conda ejolly/pymer4. For testing, the working pymer4 version is on conda channel turbach/label/pre-release pymer4 version 0.7.1.dev0 which is the same as my PR to ejolly/pymer4/dev. The pymer4 code should be close to the upcoming 0.7.1 stable release and the dependencies including the tricky rpy2 are as fresh as can be.

The fitgrid conda dependencies are now completely unpinned in meta.yaml and driven by the pymer4 conda package which is TravisCI built, conda installed and pytest tested. As of now pymer4 and fitgrid pass pytests with python 3.7, numpy 1.19, pandas 1.0+, pyarrow 1.0+, matplotlib 3.3, and rpy 3.3.

The CI is tweaked so that commits (like this PR) on branch dev with version strings M.N.P or M.N.P.devX now upload to conda channel kutaslab/label/pre-release (but not conda label main or PyPI). This closes the development/release/install loop by uploading .devX versions of conda packages to conda label pre-release. Auto-deploying the M.N.P.devX conda package means the version can be conda installed and tested as-if-by-a-user in new and existing conda envs for testing *before* doing the tagged vM.N.P stable tagged release to conda main and PyPI (the latter of which permanently burns the M.N.P version number). This allows the auto-deploy stage and conda package dependency wranglingto take place off the main release track.

The dependency updates ... pymer4, pandas, numpy, and matplotlib  ... did not require any significant refactoring, just a few tweaks in the modules and pytests.

