### PR TITLE
minor update, unpin rpy2

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,15 +16,6 @@ build:
   string: py{{environ.get("CONDA_PY", "XX")}}{{environ.get("GIT_ABBREV_COMMIT", "no_git_abbrev_commit") }}_{{ environ.get("PKG_BUILDNUM", "no_pkg_buildnum") }}
 
 requirements:
-#  build:
-  # build:
-    # conda build buggy w/ binutils_linux-65 2.35 and compiler jinja
-    # 02/07/21 conda build OK w/ binutils_linux-64 8.2.0,  gcc/gxx_linux-64 7.3.0, _sysconfigdata_x86_64_conda_cos6_linux_gnu
-    # 02/08/21 conda build fails w/ binutils_* 2.35, gxx_linux_64 9.3.0 _sysconfigdata_x86_64_conda_cos7_linux_gnu
-    # - binutils_linux-64 !=2.35
-    # revision 03/12/21 drop binutils pin, restore compiler jinjas, py36, 37, 38 ok for linux
-    # - {{ compiler('c') }}  # [linux]
-    # - {{ compiler('cxx') }}  # [linux]
   host:
     - python {{ python }}
     - pip
@@ -37,7 +28,7 @@ requirements:
     - pandas >=1.0
     # 1.0.1 fights with pandas
     - pyarrow >=1.0,!=1.0.1
-    - rpy2 !=3.4.3
+    - rpy2
     - matplotlib
     - pytables
     - tqdm

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -10,7 +10,7 @@ from .io import (
 from .models import run_model, lm, lmer
 from . import utils, defaults
 
-__version__ = "0.5.1.dev0"
+__version__ = "0.5.1.dev1"
 
 # for use by pytests and docs
 DATA_DIR = Path(__file__).parent / "data"


### PR DESCRIPTION
The pymer4 7.2 update resolved the issues caused by rpy2 > 3.4.3 changes