### PR TITLE
evaluating CI w/ mamba/boa, osx builds, and conda-forge priority

### DIFF
--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -126,7 +126,7 @@ jobs:
       # black and pytest in the py3X conda env
       - name: conda create env_${{ env.PY_VER }} python=${{ env.PY_VER }} ${{ env.PACKAGE_NAME}} and pytest
         run: |
-          mamba create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME -c local -c defaults -c conda-forge -c ejolly
+          mamba create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME "blas=*=mkl*" -c local -c ejolly -c conda-forge -c defaults --strict-channel-priority
           conda activate env_$PY_VER
           mamba install -q black pytest pytest-cov
           conda list

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -134,12 +134,19 @@ jobs:
       # 2. CI
       - name: conda build --python=${{ env.PY_VER }} conda
         id: conda-bld
+        env:
+          OS: ${{ runner.os }}   # Linux, macOS
         run: |
+
           # conda build --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
           conda mambabuild --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
           # filename is last line when conda build is chatty
           tarball=$(conda build --python=$PY_VER conda --output | tail -1)
-          conda convert -p osx-64 -p win-64 -o $CONDA_BLD_PATH $tarball
+
+          # atrocious hack, only linux job converts to win-64 for upload
+          if [[ $OS == "Linux" ]]; then \
+              conda convert -p win-64 -o $CONDA_BLD_PATH $tarball \
+          fi
           echo "conda build tarball" $tarball
           echo "::set-output name=conda-tarball::$tarball"
 
@@ -160,12 +167,12 @@ jobs:
           pytest --cov=$PACKAGE_NAME # test as installed by conda
 
       - name: build sphinx docs
-        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
+        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && matrix.os == env.DEPLOY_OS }}
         run: |
           conda activate env_$PY_VER  # required to run doc demos
           # conda install -q sphinx sphinx_rtd_theme jupyter nbsphinx "nbconvert!=5.4" -c defaults -c conda-forge
-          mamba install -q sphinx sphinx_rtd_theme sphinx-gallery -c defaults -c conda-forge
-          mamba install -q pandoc -c conda-forge
+          # conda install -q pandoc -c conda-forge
+          mamba install -q sphinx sphinx_rtd_theme sphinx-gallery pandoc #  -c defaults -c conda-forge
           make -C docs html
           touch docs/build/html/.nojekyll
 
@@ -184,6 +191,8 @@ jobs:
       # . pkg_version is entire M.N.P.devX version string
       # . pkg_mnp is M.N.P only
       - name: set DEPLOY_TYPE=<pre-release|main|no_deploy>
+        env:
+          OS: ${{ runner.os }}   # Linux, macOS
         run: |
 
           # lookup the conda tarball package version and M.N.P string (if any)
@@ -193,6 +202,7 @@ jobs:
 
           # pre-release if package version is M.N.P.devX on dev branch
           if [[ \
+            $OS == "Linux" && \
             $GITHUB_REF =~ ^refs/heads/dev$ && \
             $pkg_version =~ ^([0-9]+\.){2}[0-9]+(\.dev[0-9]+){0,1}$ \
           ]]; then \
@@ -201,6 +211,7 @@ jobs:
 
           # main if package version is M.N.P on release tag vM.N.P
           if [[ \
+            $OS == "Linux" && \
             $GITHUB_REF =~ ^refs/tags/v([0-9]+\.){2}[0-9]+$ && \
             $pkg_version == $pkg_mnp \
           ]]; then \
@@ -229,6 +240,7 @@ jobs:
           printenv | sort
           conda list --explicit
 
+      # linux and osx jobs built their own tarballs; linux-64 conda converts to win-64
       - name: deploy conda package python ${{ matrix.py_ver}} ${{ env.DEPLOY_TYPE }}
         if: ${{ env.DEPLOY_TYPE == 'pre-release' || env.DEPLOY_TYPE == 'main' }}
         env:
@@ -247,8 +259,13 @@ jobs:
 
       - name: deploy sphinx docs to gh-pages
         # switch docs deployment repo/branch on deploy type
-        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
         # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
+        if: >-
+          ${{
+          matrix.py_ver == env.DEPLOY_PY_VER
+          && matrix.os == env.DEPLOY_OS
+          && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release')
+          }}
         env:
           # machine user account PAT
           GH_USER_NAME: robo-kutaslab
@@ -256,7 +273,6 @@ jobs:
           GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
 
           # vM.N.P tagged release docs are pushed here
-          # $GITHUB_REPOSITORY
           GH_PAGES_BRANCH: gh-pages
 
           # actions on dev branch push docs to this separate repo
@@ -290,7 +306,6 @@ jobs:
           git add -A
           git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"
           git push -u origin $DOCS_BRANCH --force
-
 
       - name: deploy python package M.N.P.devX to test.pypi.org
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && env.DEPLOY_TYPE == 'pre-release' }}

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -156,7 +156,7 @@ jobs:
           lscpu
           python -c 'import numpy; numpy.show_config()'
           mamba install -q black pytest pytest-cov
-          black --diff --verbose -S -l 79 .
+          black --check --verbose -S -l 79 .
 
       - name: pytest
         run: |

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py_ver: [3.7, 3.8, 3.9]
+        py_ver: [3.7, 3.8]
 
     env:
       PY_VER: ${{ matrix.py_ver }}
@@ -100,7 +100,7 @@ jobs:
           bash miniconda.sh -b -p $HOME/miniconda
           conda shell.bash hook >> ~/.bash_profile  # instead of conda init bash
           mkdir -p $CONDA_BLD_PATH && rm miniconda.sh
-          source ~/.bash_profile && conda_activate
+          source ~/.bash_profile
           hash -r
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -104,11 +104,16 @@ jobs:
           hash -r
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH
-          conda config --set allow_conda_downgrades true
-          conda install -q conda=4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
-          conda install -q conda-build conda-verify anaconda-client twine
+          # conda config --set allow_conda_downgrades true
+          # conda install -q conda # =4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
+          conda config --add channels conda-forge
+          conda config --set channel_priority strict
           conda install -n base mamba boa -c conda-forge
+          mamba install -q conda-build conda-verify anaconda-client twine
+          echo "# ------------------------------------------------------------"
           conda info -a
+          echo "# ------------------------------------------------------------"
+          mamba info -a
 
       # ------------------------------------------------------------
       # 2. CI
@@ -123,20 +128,24 @@ jobs:
           echo "conda build tarball" $tarball
           echo "::set-output name=conda-tarball::$tarball"
 
-      # black and pytest in the py3X conda env
-      - name: conda create env_${{ env.PY_VER }} python=${{ env.PY_VER }} ${{ env.PACKAGE_NAME}} and pytest
+      # create an env w/ local package
+      - name: conda create env_${{ env.PY_VER }} python=${{ env.PY_VER }} ${{ env.PACKAGE_NAME}} and black
         run: |
-          mamba create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME "blas=*=mkl*" -c local -c ejolly -c conda-forge -c defaults --strict-channel-priority
+          black --check --verbose -S -l 79 .
+          mamba create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME "blas=*=mkl*" -c local -c ejolly # -c conda-forge -c defaults
           conda activate env_$PY_VER
           mamba install -q black pytest pytest-cov
           conda list
           lscpu
           python -c 'import numpy; numpy.show_config()'
-          black --check --verbose -S -l 79 .
+
+      - name: pytest
+        run: |
+          conda activate env_$PY_VER
           pytest --cov=$PACKAGE_NAME # test as installed by conda
 
       - name: build sphinx docs
-        # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
+        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
         run: |
           conda activate env_$PY_VER  # required to run doc demos
           # conda install -q sphinx sphinx_rtd_theme jupyter nbsphinx "nbconvert!=5.4" -c defaults -c conda-forge

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -136,7 +136,9 @@ jobs:
           OS: ${{ runner.os }}   # Linux, macOS
         run: |
 
-          conda mambabuild --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
+          # conda mambabuild --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
+          # conda-forge added in setup w/ strict priority
+          conda mambabuild --python=$PY_VER -c ejolly conda
           # filename is last line when conda build is chatty
           tarball=$(conda build --python=$PY_VER conda --output | tail -1)
 

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -4,7 +4,7 @@
 # 
 # - based on spudtr-cid.yml
 # - canonical package semantic version strings are M.N.P and M.N.P.devX
-# - job matrix runs on linux-64 for Python 3.6, 3.7, 3.8
+# - job matrix runs on linux-64 for Python 3.7, 3.8
 # - each py3X job builds, installs, pytests, and deploys its own conda py3X packages
 # - one py3X job deploys codecov, python package sdist, and docs
 # - cron runs daily to conda build, install, pytest the latest commit on default branch

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -97,11 +97,23 @@ jobs:
         run: |
           # short SHA gets baked into the conda package filename in conda/meta.yaml
           echo "GIT_ABBREV_COMMIT=_g${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda
-          conda shell.bash hook >> ~/.bash_profile  # instead of conda init bash
-          mkdir -p $CONDA_BLD_PATH && rm miniconda.sh
+          # wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+          # bash miniconda.sh -b -p $HOME/miniconda
+
+          if [[ ${{ runner.os }} == Linux ]]; then \
+            miniconda_url='https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh'; \
+          fi
+          if [[ ${{ runner.os }} == macOS ]]; then \
+            miniconda_url='https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh'; \
+          fi
+
+          wget $miniconda_url -O $HOME/miniconda.sh
+          bash ~/miniconda.sh -b -p $HOME/miniconda
+          hash -r
+          $HOME/miniconda/bin/conda shell.bash hook >> ~/.bash_profile  # instead of conda init bash
           source ~/.bash_profile
+
+          
           hash -r
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -106,7 +106,7 @@ jobs:
           conda config --set bld_path $CONDA_BLD_PATH
           conda config --set allow_conda_downgrades true
           conda install -q conda=4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
-          conda install -q conda-build conda-verify anaconda twine
+          conda install -q conda-build conda-verify anaconda-client twine
           conda install -n base mamba boa
           conda info -a
 

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -145,7 +145,7 @@ jobs:
 
           # atrocious hack, only linux job converts to win-64 for upload
           if [[ $OS == "Linux" ]]; then \
-              conda convert -p win-64 -o $CONDA_BLD_PATH $tarball \
+              conda convert -p win-64 -o $CONDA_BLD_PATH $tarball; \
           fi
           echo "conda build tarball" $tarball
           echo "::set-output name=conda-tarball::$tarball"

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -72,10 +72,11 @@ defaults:
 
 jobs:
   fitgrid-cid:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }} # ubuntu-latest
     strategy:
       matrix:
         py_ver: [3.7, 3.8]
+        os: [ubuntu-latest, macos-10.15]  # Intel macs
 
     env:
       PY_VER: ${{ matrix.py_ver }}

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -107,7 +107,7 @@ jobs:
           conda config --set allow_conda_downgrades true
           conda install -q conda=4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
           conda install -q conda-build conda-verify anaconda-client twine
-          conda install -n base mamba boa
+          conda install -n base mamba boa -c conda-forge
           conda info -a
 
       # ------------------------------------------------------------

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -117,12 +117,14 @@ jobs:
           hash -r
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH
+          conda install -q conda-build conda-verify anaconda-client twine
           # conda config --set allow_conda_downgrades true
           # conda install -q conda # =4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
+
+          # switch to mamba/boa and conda-forge
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda install -n base mamba boa -c conda-forge
-          mamba install -q conda-build conda-verify anaconda-client twine
+          conda install -n base -q mamba boa -c conda-forge
           echo "# ------------------------------------------------------------"
           conda info -a
           echo "# ------------------------------------------------------------"

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -131,13 +131,13 @@ jobs:
       # create an env w/ local package
       - name: conda create env_${{ env.PY_VER }} python=${{ env.PY_VER }} ${{ env.PACKAGE_NAME}} and black
         run: |
-          black --check --verbose -S -l 79 .
           mamba create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME "blas=*=mkl*" -c local -c ejolly # -c conda-forge -c defaults
           conda activate env_$PY_VER
-          mamba install -q black pytest pytest-cov
           conda list
           lscpu
           python -c 'import numpy; numpy.show_config()'
+          mamba install -q black pytest pytest-cov
+          black --check --verbose -S -l 79 .
 
       - name: pytest
         run: |

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -137,7 +137,7 @@ jobs:
           lscpu
           python -c 'import numpy; numpy.show_config()'
           mamba install -q black pytest pytest-cov
-          black --check --verbose -S -l 79 .
+          black --diff --verbose -S -l 79 .
 
       - name: pytest
         run: |

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -11,19 +11,19 @@
 #
 # CI:
 #
-#   - conda build, install, and pytest the conda packages linux-64 py3[678]
-#   - conda convert py3[678] x [osx-64, win-64] (untested)
+#   - conda build, install, and pytest py3[78] x [linux-64, osx-64] tarbalss
+#   - conda convert py3[78] linux-64 -> win-64 (untested)
 #   - build sphinx docs
 #   - build python package sdist
 #
 # Deployment:
 #
 #   Development: package version M.N.P.devX on dev branch triggers
-#     - anaconda upload py3X x OS-64 tarballs to channel label /pre-release
+#     - anaconda upload py3X platform tarballs to channel label /pre-release
 #     - twine python build/sdist to test.pypi.org
 #
 #   Stable release: version M.N.P on release tagged vM.N.P triggers
-#     - anaconda upload py3X x OS-64 tarballs to channel label /main
+#     - anaconda upload py3X platform tarballs to channel label /main
 #     - codecov
 #     - sphinx docs to gh-pages
 #     - twine python build/sdist to pypi.org
@@ -118,8 +118,6 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH
           conda install -q conda-build conda-verify anaconda-client twine
-          # conda config --set allow_conda_downgrades true
-          # conda install -q conda # =4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
 
           # switch to mamba/boa and conda-forge
           conda config --add channels conda-forge
@@ -138,7 +136,6 @@ jobs:
           OS: ${{ runner.os }}   # Linux, macOS
         run: |
 
-          # conda build --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
           conda mambabuild --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
           # filename is last line when conda build is chatty
           tarball=$(conda build --python=$PY_VER conda --output | tail -1)

--- a/.github/workflows/fitgrid-cid.yml
+++ b/.github/workflows/fitgrid-cid.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py_ver: [3.6, 3.7, 3.8]
+        py_ver: [3.7, 3.8, 3.9]
 
     env:
       PY_VER: ${{ matrix.py_ver }}
@@ -107,6 +107,7 @@ jobs:
           conda config --set allow_conda_downgrades true
           conda install -q conda=4.9.0  # works on mkgpu1, 4.9.2 fails here DNDC
           conda install -q conda-build conda-verify anaconda twine
+          conda install -n base mamba boa
           conda info -a
 
       # ------------------------------------------------------------
@@ -114,7 +115,8 @@ jobs:
       - name: conda build --python=${{ env.PY_VER }} conda
         id: conda-bld
         run: |
-          conda build --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
+          # conda build --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
+          conda mambabuild --python=$PY_VER -c defaults -c conda-forge -c ejolly conda
           # filename is last line when conda build is chatty
           tarball=$(conda build --python=$PY_VER conda --output | tail -1)
           conda convert -p osx-64 -p win-64 -o $CONDA_BLD_PATH $tarball
@@ -124,9 +126,9 @@ jobs:
       # black and pytest in the py3X conda env
       - name: conda create env_${{ env.PY_VER }} python=${{ env.PY_VER }} ${{ env.PACKAGE_NAME}} and pytest
         run: |
-          conda create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME -c local -c defaults -c conda-forge -c ejolly
+          mamba create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME -c local -c defaults -c conda-forge -c ejolly
           conda activate env_$PY_VER
-          conda install -q black pytest pytest-cov
+          mamba install -q black pytest pytest-cov
           conda list
           lscpu
           python -c 'import numpy; numpy.show_config()'
@@ -138,8 +140,8 @@ jobs:
         run: |
           conda activate env_$PY_VER  # required to run doc demos
           # conda install -q sphinx sphinx_rtd_theme jupyter nbsphinx "nbconvert!=5.4" -c defaults -c conda-forge
-          conda install -q sphinx sphinx_rtd_theme sphinx-gallery -c defaults -c conda-forge
-          conda install -q pandoc -c conda-forge
+          mamba install -q sphinx sphinx_rtd_theme sphinx-gallery -c defaults -c conda-forge
+          mamba install -q pandoc -c conda-forge
           make -C docs html
           touch docs/build/html/.nojekyll
 
@@ -217,7 +219,7 @@ jobs:
       - name: deploy codecov
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
         # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
-        run: conda install -q codecov && codecov
+        run: mamba install -q codecov && codecov
 
       - name: deploy sphinx docs to gh-pages
         # switch docs deployment repo/branch on deploy type

--- a/docs/source/gallery/3_model_evaluation/beta_fdr.py
+++ b/docs/source/gallery/3_model_evaluation/beta_fdr.py
@@ -88,7 +88,13 @@ p3_epochs_fg = fg.epochs_from_dataframe(
 #
 # This example summarizes a simple model with one categorical predictor: stim (2 levels: standard, target).
 lm_summary = fg.utils.summary.summarize(
-    p3_epochs_fg, modeler="lm", LHS=channels, RHS=["1 + stim",], quiet=True,
+    p3_epochs_fg,
+    modeler="lm",
+    LHS=channels,
+    RHS=[
+        "1 + stim",
+    ],
+    quiet=True,
 )
 lm_summary
 

--- a/docs/source/gallery/3_model_evaluation/lmer_warnings.py
+++ b/docs/source/gallery/3_model_evaluation/lmer_warnings.py
@@ -52,7 +52,8 @@ fitgrid.utils.lmer.plot_lmer_warnings(lmer_grid)
 # Stacking all the warning grids into one summary grid (``which="all"``)
 # shows immediately which grid cells have warnings and which do not.
 fitgrid.utils.lmer.plot_lmer_warnings(
-    lmer_grid, which="all",
+    lmer_grid,
+    which="all",
 )
 
 # %%

--- a/docs/source/gallery/3_model_evaluation/summary_plots.py
+++ b/docs/source/gallery/3_model_evaluation/summary_plots.py
@@ -124,7 +124,8 @@ figs = fitgrid.utils.summary.plot_betas(
 # For AIC :math:`\Delta_\mathsf{min}` plots the default
 # is to highlight all grid cells with warnings.
 fig, axs = fitgrid.utils.summary.plot_AICmin_deltas(
-    lmer_summaries, figsize=(12, 5),
+    lmer_summaries,
+    figsize=(12, 5),
 )
 fig.tight_layout()
 
@@ -155,7 +156,12 @@ fig.tight_layout()
 # Compute OLS fit summaries for two models
 lm_rhs = ["1 + categorical", "1 + continuous"]
 lm_summaries = fitgrid.utils.summary.summarize(
-    epochs_fg, "lm", LHS=channels, RHS=lm_rhs, parallel=False, quiet=True,
+    epochs_fg,
+    "lm",
+    LHS=channels,
+    RHS=lm_rhs,
+    parallel=False,
+    quiet=True,
 )
 lm_summaries
 

--- a/fitgrid/__init__.py
+++ b/fitgrid/__init__.py
@@ -10,7 +10,7 @@ from .io import (
 from .models import run_model, lm, lmer
 from . import utils, defaults
 
-__version__ = "0.5.1.dev2"
+__version__ = "0.5.1.dev3"
 
 # for use by pytests and docs
 DATA_DIR = Path(__file__).parent / "data"

--- a/fitgrid/sample_data.py
+++ b/fitgrid/sample_data.py
@@ -18,7 +18,7 @@ PM_1500_FEATHER = "sub000pm.ms1500.epochs.feather"
 
 
 def _download(filename, url=DATA_URL):
-    """download filename from repo url to fitgrid/data/ 
+    """download filename from repo url to fitgrid/data/
 
 
     Parameters

--- a/fitgrid/tools.py
+++ b/fitgrid/tools.py
@@ -9,8 +9,8 @@ import glob
 import warnings
 
 MKL = 'mkl'
-OBLAS = 'blas'  # matches libopenblas, libcblas
-
+OBLAS = 'openblas'
+CBLAS = 'cblas'  # numpy.show_config doesn't know if this is mkl or openblas
 
 def get_index_duplicates_table(df, level):
     """Return a string table of duplicate index values and their locations."""
@@ -49,22 +49,32 @@ def deduplicate_list(lst):
 
 
 class BLAS:
-    def __init__(self, cdll, kind):
+    """blas wrapper as determined by its thread getter/setter"""
+    def __init__(self, cdll):
 
-        if kind not in (MKL, OBLAS):
-            raise ValueError(
-                f'kind must be {MKL} or {OBLAS}, got {kind} instead.'
-            )
-
-        self.kind = kind
         self.cdll = cdll
+        self.kind = None
 
-        if kind == MKL:
+        # quack like an mkl or openblas duck or fail
+        try:
             self.get_n_threads = cdll.MKL_Get_Max_Threads
             self.set_n_threads = cdll.MKL_Set_Num_Threads
-        else:
+            self.kind = MKL
+        except Exception:
+            pass
+        
+        try:
             self.get_n_threads = cdll.openblas_get_num_threads
             self.set_n_threads = cdll.openblas_set_num_threads
+            self.kind = OBLAS
+        except Exception:
+            pass
+
+        if self.kind not in (MKL, OBLAS):
+            raise NotImplementedError(
+                f"BLAS must be {MKL} or {OBLAS} in {str(cdll)}"
+           )
+
 
     def __repr__(self):
         if self.kind == MKL:
@@ -107,14 +117,13 @@ def get_blas_osys(numpy_module, osys):
     )
 
     output = ldd_result.stdout
-
-    kinds = [MKL, OBLAS]
+    kinds = [MKL, OBLAS, CBLAS]
     for kind in kinds:
         match = re.search(PATTERN.format(kind), output, flags=re.MULTILINE)
         if match:
             path = match.groupdict()['path']
             cdll = ctypes.CDLL(path)
-            return BLAS(cdll, kind)
+            return BLAS(cdll)
 
     # unknown kind
     return None

--- a/fitgrid/tools.py
+++ b/fitgrid/tools.py
@@ -12,6 +12,7 @@ MKL = 'mkl'
 OBLAS = 'openblas'
 CBLAS = 'cblas'  # numpy.show_config doesn't know if this is mkl or openblas
 
+
 def get_index_duplicates_table(df, level):
     """Return a string table of duplicate index values and their locations."""
 
@@ -50,6 +51,7 @@ def deduplicate_list(lst):
 
 class BLAS:
     """blas wrapper as determined by its thread getter/setter"""
+
     def __init__(self, cdll):
 
         self.cdll = cdll
@@ -62,7 +64,7 @@ class BLAS:
             self.kind = MKL
         except Exception:
             pass
-        
+
         try:
             self.get_n_threads = cdll.openblas_get_num_threads
             self.set_n_threads = cdll.openblas_set_num_threads
@@ -73,8 +75,7 @@ class BLAS:
         if self.kind not in (MKL, OBLAS):
             raise NotImplementedError(
                 f"BLAS must be {MKL} or {OBLAS} in {str(cdll)}"
-           )
-
+            )
 
     def __repr__(self):
         if self.kind == MKL:

--- a/fitgrid/utils/summary.py
+++ b/fitgrid/utils/summary.py
@@ -624,7 +624,7 @@ def summaries_fdr_control(
     rate=0.05,
     plot_pvalues=True,
 ):
-    """False discovery rate control for non-zero betas in model summary dataframes
+    r"""False discovery rate control for non-zero betas in model summary dataframes
 
     The family of tests for FDR control is assumed to be **all and
     only** the channels, models, and :math:`\hat{\beta}_i` in the

--- a/fitgrid/utils/summary.py
+++ b/fitgrid/utils/summary.py
@@ -619,7 +619,10 @@ def _get_AICs(summary_df):
 
 
 def summaries_fdr_control(
-    model_summary_df, method="BY", rate=0.05, plot_pvalues=True,
+    model_summary_df,
+    method="BY",
+    rate=0.05,
+    plot_pvalues=True,
 ):
     """False discovery rate control for non-zero betas in model summary dataframes
 
@@ -638,7 +641,7 @@ def summaries_fdr_control(
         Hochberg [2]_.
     rate : float {0.05}
         The target rate for controlling false discoveries.
-    plot_pvalues : bool {True, False} 
+    plot_pvalues : bool {True, False}
         Display a plot of the family of $p$-values and critical value for FDR control.
 
 
@@ -883,7 +886,12 @@ def plot_betas(
         model_summary_df.sort_index(inplace=True)
         model_summary_df = model_summary_df.loc[
             # Index = time, model, beta, key
-            pd.IndexSlice[interval[0] : interval[1], :, :, :,],
+            pd.IndexSlice[
+                interval[0] : interval[1],
+                :,
+                :,
+                :,
+            ],
             :,
         ]
 
@@ -1063,7 +1071,7 @@ def plot_AICmin_deltas(
     show_warnings : {"no_labels", "labels", str, list of str}
        "no_labels" (default) highlights everywhere there is any warning in
        red, the default behavior in fitgrid < v0.5.0. "labels" display
-       all warning strings the axes titles.  A `str` or list of `str` selects 
+       all warning strings the axes titles.  A `str` or list of `str` selects
        and display only warnings that (partial) match a model warning string.
 
     figsize : 2-ple
@@ -1104,7 +1112,7 @@ def plot_AICmin_deltas(
     """
 
     def _get_warnings_grid(model_warnings, show_warnings):
-        """look up warnings according to aic and user kwarg value """
+        """look up warnings according to aic and user kwarg value"""
 
         # split the "_" separated multiple warning strings into unique types
         warning_kinds = np.unique(
@@ -1238,7 +1246,10 @@ def plot_AICmin_deltas(
                 _min_deltas[chan].where(warnings_grid[chan] == 1).dropna()
             )
             traces.scatter(
-                chan_mask.index, chan_mask, c="crimson", label=None,
+                chan_mask.index,
+                chan_mask,
+                c="crimson",
+                label=None,
             )
 
         if i == 0:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -62,7 +62,6 @@ def test_blas_getter():
     assert blas.get_n_threads() == 1
 
 
-
 def test_single_threaded_no_change():
 
     import numpy

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -41,21 +41,26 @@ def test_blas_osys():
         assert tools.get_blas_osys(numpy, 'darwin') is None
 
 
-@pytest.mark.skipif(
-    'GITHUB_ACTIONS' in os.environ,
-    reason='https://github.com/kutaslab/fitgrid/issues/86',
-)
+# @pytest.mark.skipif(
+#     'GITHUB_ACTIONS' in os.environ,
+#     reason='https://github.com/kutaslab/fitgrid/issues/86',
+# )
 def test_blas_getter():
 
     import numpy
 
     blas = tools.get_blas(numpy)
 
-    blas.set_n_threads(4)
-    assert blas.get_n_threads() == 4
+    if not 'GITHUB_ACTIONS' in os.environ:
+        blas.set_n_threads(4)
+        assert blas.get_n_threads() == 4
 
     blas.set_n_threads(2)
     assert blas.get_n_threads() == 2
+
+    blas.set_n_threads(1)
+    assert blas.get_n_threads() == 1
+
 
 
 def test_single_threaded_no_change():

--- a/tests/test_utils_summary.py
+++ b/tests/test_utils_summary.py
@@ -175,7 +175,7 @@ bad_epochs_mark = pytest.mark.xfail(reason=TypeError, strict=True)
     ],
 )
 def test_summarize_args(epoch_arg):
-    """ test summary.summarize argument guards"""
+    """test summary.summarize argument guards"""
     fitgrid.utils.summary.summarize(epoch_arg, None, None, None, None, None)
 
 


### PR DESCRIPTION
* Add osx-64 platform to job matrix for conda package build, pytest, and anaconda.corg upload
* Drop Python 3.6 ... h5py 3.2 minimum Python version is 3.7
* add conda-forge to .condarc and set channel_priority=strict for build, install
* replace conda build with boa and conda mambabuild: https://github.com/mamba-org/boa
* replace conda create/install with mamba create/install: https://github.com/mamba-org/mamba

Note: mamba has an affinity for conda-forge and conda-forge has an affinity for openblas. To retain mkl blas for pytesting in the test conda environment the CI attempts to override the conda-forge openblas by installing "blas=*=mkl*" along with fitgrid.
