### PR TITLE
[JOSS] rst syntax fixes

### DIFF
--- a/docs/source/about_fitgrid.rst
+++ b/docs/source/about_fitgrid.rst
@@ -115,21 +115,21 @@ The `fitgrid` package allows researchers generally familiar with
 regression modeling and model specification formulas in Python
 (`statsmodels.formula.api` via `patsy`) or R (`lm`, `lme4`,
 `lmerTest`) to use these tools to readily and reproducibly fit
-ordinary least squares and linear mixed-effects regression models of 
+ordinary least squares and linear mixed-effects regression models of
 multichannel event-related time series recordings, at scale, with
-a few lines of scripted Python. 
+a few lines of scripted Python.
 
 With one function call, `fitgrid` sweeps a model formula across the
 data observations at each time and channel (in parallel on multiple CPU
 cores if supported by hardware) and collects the resulting fit objects
 returned by `statsmodels.ols` or `lme4::lmer` via `pymer4` in a
-single `FitGrid[times, channels]` Python object. 
+single `FitGrid[times, channels]` Python object.
 
 The `FitGrid` can be sliced by time and channel like a dataframe, and
 the results for a fit attribute are queried for the entire grid with
 the same syntax as single fit: ``results = FitGrid.<attr>``. The
 results include the time-series of coefficient estimates comprising
-the regression ERPs, including, but not restricted to, the special 
+the regression ERPs, including, but not restricted to, the special
 case average ERP.  Equally important for modeling, the results also include
 everything else in the bundle of information comprising the fit object
 such as coefficient standard errors, model log likelihood, Akiake's
@@ -157,7 +157,7 @@ For illustration with `patsy` and `statsmodels`, suppose you have a
 pandas DataFrame ``data`` with independent variables ``x`` and ``a``,
 where ``x`` is continuous and ``a`` is categorical. Suppose also
 ``channel`` is your continuous dependent variable.  Here's how you
-would run an ordinary least squares linear regression of ``y`` on
+would run an ordinary least squares linear regression of ``channel`` on
 ``x + a`` using `statsmodels <http://www.statsmodels.org>`_::
 
     from statsmodels.formula.api import ols
@@ -171,7 +171,7 @@ accessing various attributes of ``fit``. For example, the betas::
     betas = fit.params
 
 or the t-values::
-    
+
     tvalues = fit.tvalues
 
 or :math:`Pr(>|t|)`::
@@ -179,7 +179,7 @@ or :math:`Pr(>|t|)`::
     pvalues = fit.pvalues
 
 Compare to R, where this is usually done by calling functions like ``summary``
-or ``coef``. 
+or ``coef``.
 
 Now the issue with using that interface for single trial rERP analyses
 is of course the dimensionality: instead of fitting a single model, we
@@ -260,6 +260,6 @@ can also be used with sensor array time-series data from other domains
 where event-related signal averaging and and regression modeling is
 appropriate. The :ref:`gallery` includes hourly NOAA tide and
 atmospheric data to illustrate event-related time-domain aggregation
-to detect lunar atmospheric tides, an approach first attempted by 
+to detect lunar atmospheric tides, an approach first attempted by
 Laplace in the early 19th century [LinCha1969]_.
 

--- a/docs/source/gallery/1_epochs_data/noaa_csv_to_epochs.py
+++ b/docs/source/gallery/1_epochs_data/noaa_csv_to_epochs.py
@@ -4,29 +4,29 @@ NOAA tides and weather epochs
 =============================
 
 This example wrangles about 10 years of somewhat messy hourly NOAA
-`meteorological observations 
+`meteorological observations
 <https://tidesandcurrents.noaa.gov/met.html?id=9410230&units=standard&timezone=GMT&action=data>`_
 and `water levels
 <https://tidesandcurrents.noaa.gov/waterlevels.html?id=9410230&units=standard&timezone=GMT&action=data>`_
 into tidy `pandas.DataFrame` of time-stamped epochs ready to
 load as `fitgrid.Epochs` for modeling.
- 
+
 1. Groom separate NOAA ocean water level and atmospheric observation
-data files and merge into a single time-stamped `pandas.DataFrame`.
+   data files and merge into a single time-stamped `pandas.DataFrame`.
 
 2. Add a column of event tags that mark the `high_tide` time-locking events of interest.
 
 3. Snip the time-series apart into fixed length epochs and construct a
-new column of time-stamps in each epoch with the `high_tide` event of
-interest at time=0.
+   new column of time-stamps in each epoch with the `high_tide` event of
+   interest at time=0.
 
 4. Export the epochs data frame to save for later use in `fitgrid`
 
-Data Source: 
+Data Source:
 
-| NOAA CO-OPS-9419230  
-| Station: La Jolla, CA 94102 (Scripps Pier)   
-| August 1, 2010 - July 1, 2020  
+| NOAA CO-OPS-9419230
+| Station: La Jolla, CA 94102 (Scripps Pier)
+| August 1, 2010 - July 1, 2020
 
 The water levels are measured relative to mean sea level (MSL). For
 further information about these data see `tide data options

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -17,16 +17,16 @@ the :ref:`workflow`, :ref:`gallery`, and :ref:`api`
 `fitgrid.Epochs`
 ================
 
-Fitting linear regression models in Python and R with formulas like `y
-~ a + b + a:b` in Python (`patsy`, `statsmodels.formula.api`) or R (`lm`,
-`lme4::lmer`) assumes the data are represented as a 2D array with the
-variables in named columns, `y`, `a`, `b` and values ("observations",
-"scores") in rows.
+Fitting linear regression models in Python and R with formulas like
+``y ~ a + b + a:b`` in Python (`patsy`, `statsmodels.formula.api`) or R
+(`lm`, `lme4::lmer`) assumes the data are represented as a 2D array with
+the variables in named columns, ``y``, ``a``, ``b`` and values
+("observations", "scores") in rows.
 
 `fitgrid` follows this format with the additional assumption that the
 data are vertically stacked fixed-length time-series "epochs", so the
 user must specify two additional columns of values that together
-uniquely identify the epoch and time of the data row. 
+uniquely identify the epoch and time of the data row.
 
 
 .. _epochs_data_format:
@@ -73,7 +73,7 @@ chart and time-stamped relative to an experimental event.
 
 Rows and columns epochs data can be loaded into a `fitgrid.Epochs`
 object from a `pandas.DataFrame` in memory or read from files in
-feather or HDF5 format. 
+feather or HDF5 format.
 
 For details on these data formats see `pandas.read_feather
 <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_feather.html>`_
@@ -121,7 +121,7 @@ Fitting a model
 
 The following methods populate the `FitGrid[time, channel]` object.
 with `statsmodels` results for OLS model fits and `lme4::lmer` for
-linear mixed-effects fits. 
+linear mixed-effects fits.
 
 * Ordinary least squares: :py:meth:`fitgrid.lm`
 
@@ -158,7 +158,7 @@ The `FitGrid[time, channel]`
 Slice by `time`, `channel`
 --------------------------
 
- 
+
 Slice the `FitGrid` with `pandas.DataFrame` range ``:`` and label slicers.
 The range includes the upper bound.
 
@@ -320,12 +320,12 @@ To deal with this when running ``fitgrid.lm``, we try to instruct the
 linear algebra libraries your ``numpy`` distribution depends on to
 only use a single thread in every computation. This then lets you
 control the number of CPU cores being used by setting the ``n_cores``
-parameter in :py:meth:`fitgrid.lm` and :py:meth:`fitgrid.lmer`. 
+parameter in :py:meth:`fitgrid.lm` and :py:meth:`fitgrid.lmer`.
 
 If you are using your own 8-core laptop, you might want to use all
 cores, so set something like ``n_cores=7``. On a shared machine, it's
 a good idea to run on half or 3/4 of the cores if no one else is
-running heavy computations. 
+running heavy computations.
 
 Note that fitgrid parallel processing counts the "logical" cores
 available to the operating system and this may differ from the number


### PR DESCRIPTION
(related to openjournals/joss-reviews#3293)

While going through the docs, I found two rst syntax issues: once you used single backticks instead of double backticks, leading to a patsy-style formula being represented in italics, instead of inline code.

The other one is on indentation in a list, which was missing and is now fixed.

All other lines that are touched had trailing whitespace that my editor removed automatically.