### PR TITLE
[JOSS] Make standalone doc pages "orphans"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# built files
+docs/source/auto_gallery/*
+
 # TODOs files
 *.todo
 

--- a/docs/source/api_docs/modules.rst
+++ b/docs/source/api_docs/modules.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 fitgrid
 =======
 

--- a/docs/source/gallery/1_epochs_data/README.rst
+++ b/docs/source/gallery/1_epochs_data/README.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Epochs data
 ===========
 

--- a/docs/source/gallery/2_model_fitting/README.rst
+++ b/docs/source/gallery/2_model_fitting/README.rst
@@ -1,2 +1,4 @@
+:orphan:
+
 Model fitting
 =============

--- a/docs/source/gallery/3_model_evaluation/README.rst
+++ b/docs/source/gallery/3_model_evaluation/README.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Model evaluation
 ================
 

--- a/docs/source/gallery/README.rst
+++ b/docs/source/gallery/README.rst
@@ -1,2 +1,4 @@
+:orphan:
+
 Examples
 ========


### PR DESCRIPTION
(related to https://github.com/openjournals/joss-reviews/issues/3293)

to purge sphinx build warnings that are unhelpful. In particular, these warnings will no longer show up afterwards:

> WARNING: document isn't included in any toctree